### PR TITLE
Fix for current NLog Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Syslog Target for NLog
 ======================
 
-**NLog Syslog** is a custom target for [NLog](http://nlog-project.org/) version 2.0 allowing you to send logging messages to a UNIX-style Syslog server.
+**NLog Syslog** is a custom target for [NLog](http://nlog-project.org/) allowing you to send logging messages to a UNIX-style Syslog server.
 
 ## Configuration
 

--- a/src/NLog.Targets.Syslog/NLog.Targets.Syslog.csproj
+++ b/src/NLog.Targets.Syslog/NLog.Targets.Syslog.csproj
@@ -40,9 +40,9 @@
     <AssemblyOriginatorKeyFile>NLog.Targets.Syslog.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NLog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NLog.2.0.0.2000\lib\net35\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.1.2\lib\net35\NLog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/NLog.Targets.Syslog/SyslogSeverity.cs
+++ b/src/NLog.Targets.Syslog/SyslogSeverity.cs
@@ -48,6 +48,6 @@
         /// <summary>
         /// debug-level messages
         /// </summary>
-        Debug = 7
+        Debug = 7,
     }
 }

--- a/src/NLog.Targets.Syslog/packages.config
+++ b/src/NLog.Targets.Syslog/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NLog" version="2.0.0.2000" targetFramework="net35" />
+  <package id="NLog" version="4.1.2" targetFramework="net35" />
 </packages>

--- a/src/TestApp/TestApp.csproj
+++ b/src/TestApp/TestApp.csproj
@@ -36,9 +36,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NLog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NLog.2.0.0.2000\lib\net40\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.1.2\lib\net40\NLog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/TestApp/packages.config
+++ b/src/TestApp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NLog" version="2.0.0.2000" targetFramework="net40-Client" />
+  <package id="NLog" version="4.1.2" targetFramework="net40-Client" />
 </packages>


### PR DESCRIPTION
I could not use this lib with current version of NLog. It was fixed to NLog 2.0 . So i changed that and testet the lib with NLog 4.1.2 and 3.1.0. It was working fine for me. I would be happy if you could merge this branche to master.