### PR TITLE
Added support for rfc5424

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,28 +40,41 @@ Optionally, your configuration can override them using attributes on
 * `port`: Port of syslog listener (default: `514`)
 * `protocol`: `udp` or `tcp` (default: `udp`)
 * `ssl`: `false` or `true`; TCP only (default: `false`)
+* `rfc`: Rfc compatibility for syslog message `Rfc3164` or `Rfc5424` (default: `Rfc3164`)
 
 #### Syslog packet elements
 
 Messages are sent using the format (framing) called syslog, which is
-defined in [RFC 3164](http://www.ietf.org/rfc/rfc3164.txt). In addition
+defined in [RFC 3164](http://www.ietf.org/rfc/rfc3164.txt) or 
+[RFC 5424](http://tools.ietf.org/html/rfc5424). In addition
 to a timestamp and the log message, RFC 3164 syslog messages include
 other elements: sending device name (such as the machine's hostname),
 sending app/component name (called "tag" in the RFC), facility, and
 severity.
 
-The following syslog elements can be overridden:
+The following syslog elements can be overridden for RFC 3164:
 
-* `machinename`: name of sending system or entity (default: machine 
-  [hostname](http://msdn.microsoft.com/en-us/library/system.net.dns.gethostname(v=vs.110).aspx))
-* `sender`: name of sending component or application (default: 
-  [calling method](http://msdn.microsoft.com/en-us/library/system.reflection.assembly.getcallingassembly(v=vs.110).aspx))
+* `machinename` ([Layout](https://github.com/NLog/NLog/wiki/Layouts)): name of sending system or entity (default: machine 
+  [hostname](http://msdn.microsoft.com/en-us/library/system.net.dns.gethostname(v=vs.110).aspx)).
+For example, ${machinename}
+* `sender` ([Layout](https://github.com/NLog/NLog/wiki/Layouts)): name of sending component or application (default: 
+  [calling method](http://msdn.microsoft.com/en-us/library/system.reflection.assembly.getcallingassembly(v=vs.110).aspx)).
+For example, ${logger}
 * `facility`: facility name (default: `Local1`)
 
 For example, to make logs from multiple systems use the same device
 identifier (rather than each system's hostname), one could set
 `machinename` to `app-cloud`. The logs from different systems would
 all appear to be from the same single entity called `app-cloud`.
+
+The following additional syslog elements can be overridden for [RFC 5424](http://tools.ietf.org/html/rfc5424):
+
+* `procid` ([Layout](https://github.com/NLog/NLog/wiki/Layouts)): [identifier](http://tools.ietf.org/html/rfc5424#section-6.2.6) (numeric or alphanumeric) of sending entity 
+(default: -). For example, ${processid} or ${processname}
+* `msgid` ([Layout](https://github.com/NLog/NLog/wiki/Layouts)): [message type identifier](http://tools.ietf.org/html/rfc5424#section-6.2.7) (numeric or alphanumeric) of sending entity 
+(default: -). For example, ${callsite}
+* `structureddata` ([Layout](https://github.com/NLog/NLog/wiki/Layouts)): [additional data](http://tools.ietf.org/html/rfc5424#section-6.3) of sending entity (default: -).
+For example, [thread@12345 id="${threadid}" name="${threadname}"][mydata2@12345 num="1" code="mycode"]
 
 #### Log message body
 

--- a/src/NLog.Targets.Syslog/NLog.Targets.Syslog.csproj
+++ b/src/NLog.Targets.Syslog/NLog.Targets.Syslog.csproj
@@ -52,6 +52,7 @@
   <ItemGroup>
     <Compile Include="NLog.Targets.Syslog.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RfcNumber.cs" />
     <Compile Include="SyslogFacility.cs" />
     <Compile Include="SyslogSeverity.cs" />
   </ItemGroup>

--- a/src/NLog.Targets.Syslog/RfcNumber.cs
+++ b/src/NLog.Targets.Syslog/RfcNumber.cs
@@ -1,0 +1,8 @@
+﻿namespace NLog.Targets
+{
+    public enum RfcNumber
+    {
+        Rfc3164 = 3164,
+        Rfc5424 = 5424
+    }
+}

--- a/src/TestApp/NLog.config
+++ b/src/TestApp/NLog.config
@@ -21,25 +21,28 @@
       facility="Local7"
       sender="MyProgram"
       layout="[CustomPrefix] ${machinename} ${message} ${callsite} ${exception:format=ToString,StackTrace}" />
-    
-    <target
-      name="syslog-new"
-      type="Syslog"
-      syslogserver="127.0.0.1"
-      port="514"
-      facility="Local7"
-      rfc="Rfc5424"
-      machineName="${machinename}"
-      sender="${logger}"
-      procid="${processid}"
-      msgid="testmsgid"
-      structureddata="[thread@${enterpriseId} id=&quot;${threadid}&quot;]"
-      layout="${message} ${exception:format=ToString,StackTrace}" />
+
+    <target type="AsyncWrapper" name="async">
+      <target
+        name="syslog-new"
+        type="Syslog"
+        syslogserver="127.0.0.1"
+        port="514"
+        facility="Local7"
+        rfc="Rfc5424"
+        machineName="${machinename}"
+        sender="${logger}"
+        procid="${processid}"
+        msgid="testmsgid"
+        structureddata="[thread@${enterpriseId} id=&quot;${threadid}&quot;]"
+        layout="${message} ${exception:format=ToString,StackTrace}" />
+      </target>
   </targets>
 
   <rules>
     <!--<logger name="*" minLevel="Trace" appendTo="syslog"/>-->
-    <logger name="*" minLevel="Trace" appendTo="syslog-new"/>
+    <!--<logger name="*" minLevel="Trace" appendTo="syslog-new"/>-->
+    <logger name="*" minLevel="Trace" appendTo="async"/>
   </rules>
 
 </nlog>

--- a/src/TestApp/NLog.config
+++ b/src/TestApp/NLog.config
@@ -10,6 +10,8 @@
     <add assembly="NLog.Targets.Syslog" />
   </extensions>
 
+  <variable name="enterpriseId" value="12345"/>
+
   <targets>
     <target
       name="syslog"
@@ -19,10 +21,25 @@
       facility="Local7"
       sender="MyProgram"
       layout="[CustomPrefix] ${machinename} ${message} ${callsite} ${exception:format=ToString,StackTrace}" />
+    
+    <target
+      name="syslog-new"
+      type="Syslog"
+      syslogserver="127.0.0.1"
+      port="514"
+      facility="Local7"
+      rfc="Rfc5424"
+      machineName="${machinename}"
+      sender="${logger}"
+      procid="${processid}"
+      msgid="testmsgid"
+      structureddata="[thread@${enterpriseId} id=&quot;${threadid}&quot;]"
+      layout="${message} ${exception:format=ToString,StackTrace}" />
   </targets>
 
   <rules>
-    <logger name="*" minLevel="Trace" appendTo="syslog"/>
+    <!--<logger name="*" minLevel="Trace" appendTo="syslog"/>-->
+    <logger name="*" minLevel="Trace" appendTo="syslog-new"/>
   </rules>
 
 </nlog>


### PR DESCRIPTION
* Added support for RFC 5424 message format. ProcId, MsgId, StructuredData are layouts.
* Message timestamp is now rendered from logEvent.TimeStamp.
* Sender and MachineName parameters now are Layouts.

Default mode is RFC 3164.

