### PR TITLE
Fix duplication of left bracket in SD element

### DIFF
--- a/src/NLog.Targets.Syslog/MessageCreation/SdElement.cs
+++ b/src/NLog.Targets.Syslog/MessageCreation/SdElement.cs
@@ -65,7 +65,6 @@ namespace NLog.Targets.Syslog.MessageCreation
         private static IEnumerable<byte> Bytes(IEnumerable<byte> sdIdBytes, IEnumerable<byte> sdParamsBytes)
         {
             return LeftBracketBytes
-                .Concat(LeftBracketBytes)
                 .Concat(sdIdBytes)
                 .Concat(sdParamsBytes)
                 .Concat(RightBracketBytes);


### PR DESCRIPTION
SD elements are currently being sent with two left brackets, causing the id and params to be misinterpreted by some syslog implementations.

The extra bracket can be seen in this screenshot from wireshark:
![wireshark](https://cloud.githubusercontent.com/assets/1843264/16342933/7f36e782-3a2c-11e6-9907-2301ba3e3483.png)

We're using Loggly and the extra bracket is resulting in the sd-params being ignored:
![loggly-error](https://cloud.githubusercontent.com/assets/1843264/16342610/f838a80c-3a2a-11e6-9b4a-e600fea655fb.png)

Once the extra bracket is removed, the log appears correctly:
![loggly-fixed](https://cloud.githubusercontent.com/assets/1843264/16342668/534fbb68-3a2b-11e6-9a0c-2b477ffaa704.png)

