### PR TITLE
Use CompoundLayout to avoid invalid CEE JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Syslog target for NLog
 ======================
 **NLog Syslog** is a custom target for **NLog**: [http://nlog-project.org](http://nlog-project.org/).
 
-It can be used with version 4.3.2 and later of NLog and allows to send logging messages to a Unix-style Syslog server.
+It can be used with version 4.3.6 and later of NLog and allows to send logging messages to a Unix-style Syslog server.
 
 
 

--- a/src/NLog.Targets.Syslog/NLog.Targets.Syslog.csproj
+++ b/src/NLog.Targets.Syslog/NLog.Targets.Syslog.csproj
@@ -43,7 +43,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.3.3\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.3.6\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/NLog.Targets.Syslog/packages.config
+++ b/src/NLog.Targets.Syslog/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NLog" version="4.3.3" targetFramework="net45" />
+  <package id="NLog" version="4.3.6" targetFramework="net45" />
   <package id="UnidecodeSharpFork" version="1.0.0" targetFramework="net45" />
 </packages>

--- a/src/TestApp/NLog.config
+++ b/src/TestApp/NLog.config
@@ -102,7 +102,16 @@
             </sl:messageTransmitter>
         </target>
         <target xsi:type="sl:Syslog" name="syslogcee-tgt">
-            <sl:layout xsi:type="SimpleLayout" text="@cee: {&quot;message&quot;: &quot;${message}&quot;}" />
+            <sl:layout xsi:type="CompoundLayout">
+                <layout xsi:type="SimpleLayout" text="@cee: " />
+                <layout xsi:type="JsonLayout">
+                    <attribute name="env" layout="DEV" />
+                    <attribute name="area" layout="Provisioning" />
+                    <attribute name="category" layout="Console" />
+                    <attribute name="app" layout="TestApp" />
+                    <attribute name="message" layout="${message}" />
+                </layout>
+            </sl:layout>
             <sl:enforcement>
                 <sl:splitOnNewLine>false</sl:splitOnNewLine>
                 <sl:transliterate>false</sl:transliterate>

--- a/src/TestApp/NLog.xsd
+++ b/src/TestApp/NLog.xsd
@@ -1020,8 +1020,8 @@
           <xs:element name="archiveFileName" minOccurs="0" maxOccurs="1" type="Layout" />
           <xs:element name="archiveEvery" minOccurs="0" maxOccurs="1" type="NLog.Targets.FileArchivePeriod" />
           <xs:element name="archiveAboveSize" minOccurs="0" maxOccurs="1" type="xs:long" />
-          <xs:element name="maxArchiveFiles" minOccurs="0" maxOccurs="1" type="xs:integer" />
           <xs:element name="enableArchiveFileCompression" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="maxArchiveFiles" minOccurs="0" maxOccurs="1" type="xs:integer" />
           <xs:element name="forceManaged" minOccurs="0" maxOccurs="1" type="xs:boolean" />
           <xs:element name="cleanupFileName" minOccurs="0" maxOccurs="1" type="xs:boolean" />
           <xs:element name="fileName" minOccurs="0" maxOccurs="1" type="Layout" />
@@ -1093,14 +1093,14 @@
             <xs:documentation>Size in bytes above which log files will be automatically archived. Warning: combining this with  isn't supported. We cannot create multiple archive files, if they should have the same name. Choose: </xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="maxArchiveFiles" type="xs:integer">
-          <xs:annotation>
-            <xs:documentation>Maximum number of archive files that should be kept.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
         <xs:attribute name="enableArchiveFileCompression" type="xs:boolean">
           <xs:annotation>
             <xs:documentation>Indicates whether to compress archive files into the zip archive format.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxArchiveFiles" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum number of archive files that should be kept.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="forceManaged" type="xs:boolean">
@@ -2238,6 +2238,15 @@
       <xs:enumeration value="HttpGet" />
     </xs:restriction>
   </xs:simpleType>
+  <xs:complexType name="CompoundLayout">
+    <xs:complexContent>
+      <xs:extension base="Layout">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="layout" minOccurs="0" maxOccurs="unbounded" type="Layout" />
+        </xs:choice>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
   <xs:complexType name="CsvLayout">
     <xs:complexContent>
       <xs:extension base="Layout">

--- a/src/TestApp/NLog.xsd
+++ b/src/TestApp/NLog.xsd
@@ -232,7 +232,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="Layout"></xs:complexType>
   <xs:complexType name="Filter" abstract="true"></xs:complexType>
   <xs:complexType name="TimeSource" abstract="true"></xs:complexType>
   <xs:simpleType name="SimpleLayoutAttribute">
@@ -2246,6 +2245,9 @@
         </xs:choice>
       </xs:extension>
     </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="Layout">
+    <xs:choice minOccurs="0" maxOccurs="unbounded" />
   </xs:complexType>
   <xs:complexType name="CsvLayout">
     <xs:complexContent>

--- a/src/TestApp/TestApp.csproj
+++ b/src/TestApp/TestApp.csproj
@@ -38,7 +38,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.3.3\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.3.6\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -75,9 +75,7 @@
     <None Include="NLog.xsd">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/src/TestApp/packages.config
+++ b/src/TestApp/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NLog" version="4.3.3" targetFramework="net45" />
-  <package id="NLog.Schema" version="4.3.0" targetFramework="net45" />
+  <package id="NLog" version="4.3.6" targetFramework="net45" />
+  <package id="NLog.Schema" version="4.3.6" targetFramework="net45" />
 </packages>

--- a/src/TestApp/packages.config
+++ b/src/TestApp/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NLog" version="4.3.6" targetFramework="net45" />
-  <package id="NLog.Schema" version="4.3.6" targetFramework="net45" />
+  <package id="NLog.Schema" version="4.3.6.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
With NLog 4.3.6 a [CompoundLayout](https://github.com/nlog/nlog/wiki/CompoundLayout) has been released.

I updated NuGet packages and changed the test app configuration so that CEE is always valid JSON.