### PR TITLE
Handle intermittent Syslog server

### DIFF
--- a/src/NLog.Targets.Syslog.sln
+++ b/src/NLog.Targets.Syslog.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.Targets.Syslog", "NLog.Targets.Syslog\NLog.Targets.Syslog.csproj", "{D888EE7E-4394-4FB1-9B37-29513FF8A91A}"
 EndProject
@@ -9,7 +9,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApp", "TestApp\TestApp.
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9B0D1054-6E68-4208-97BC-12F254CF3754}"
 	ProjectSection(SolutionItems) = preProject
-		License.txt = License.txt
+		..\License.txt = ..\License.txt
 		schemas\NLog.Targets.Syslog.xsd = schemas\NLog.Targets.Syslog.xsd
 		..\README.md = ..\README.md
 	EndProjectSection

--- a/src/NLog.Targets.Syslog/AsyncLogger.cs
+++ b/src/NLog.Targets.Syslog/AsyncLogger.cs
@@ -53,7 +53,7 @@ namespace NLog.Targets.Syslog
             return ProcessQueueAsync(messageBuilder, new TaskCompletionSource<object>())
                 .ContinueWith(t =>
                 {
-                    InternalLogger.Debug(t.Exception?.GetBaseException(), "ProcessQueueAsync faulted within try");
+                    InternalLogger.Warn(t.Exception?.GetBaseException(), "ProcessQueueAsync faulted within try");
                     return ProcessQueueAsync(messageBuilder);
                 }, token, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Current)
                 .Unwrap();
@@ -80,7 +80,7 @@ namespace NLog.Targets.Syslog
                             return tcs.CanceledTask();
                         }
                         if (t.Exception != null) // t.IsFaulted is true
-                            InternalLogger.Debug(t.Exception.GetBaseException(), "Task faulted");
+                            InternalLogger.Warn(t.Exception.GetBaseException(), "Task faulted");
                         else
                             InternalLogger.Debug($"Successfully sent message '{logEventMsgSet}'");
                         return ProcessQueueAsync(messageBuilder, tcs);

--- a/src/NLog.Targets.Syslog/Extensions/TaskExtensions.cs
+++ b/src/NLog.Targets.Syslog/Extensions/TaskExtensions.cs
@@ -25,6 +25,18 @@ namespace NLog.Targets.Syslog.Extensions
                 .Unwrap();
         }
 
+        public static Task SafeFromAsync<TArg1, TArg2, TArg3>(this TaskFactory taskFactory, Func<TArg1, TArg2, TArg3, AsyncCallback, object, IAsyncResult> beginMethod, Action<IAsyncResult> endMethod, TArg1 arg1, TArg2 arg2, TArg3 arg3, object state)
+        {
+            try
+            {
+                return taskFactory.FromAsync(beginMethod, endMethod, arg1, arg2, arg3, state);
+            }
+            catch (Exception exception)
+            {
+                return new TaskCompletionSource<object>().FailedTask(exception);
+            }
+        }
+
         public static Task CanceledTask(this TaskCompletionSource<object> tcs)
         {
             tcs.SetCanceled();
@@ -43,18 +55,6 @@ namespace NLog.Targets.Syslog.Extensions
             action?.Invoke(exception);
             tcs.SetException(exception);
             return tcs.Task;
-        }
-
-        public static Task SafeFromAsync<TArg1, TArg2, TArg3>(this TaskFactory taskFactory, Func<TArg1, TArg2, TArg3, AsyncCallback, object, IAsyncResult> beginMethod, Action<IAsyncResult> endMethod, TArg1 arg1, TArg2 arg2, TArg3 arg3, object state)
-        {
-            try
-            {
-                return taskFactory.FromAsync(beginMethod, endMethod, arg1, arg2, arg3, state);
-            }
-            catch (Exception exception)
-            {
-                return new TaskCompletionSource<object>().FailedTask(exception);
-            }
         }
     }
 }

--- a/src/NLog.Targets.Syslog/Extensions/TaskExtensions.cs
+++ b/src/NLog.Targets.Syslog/Extensions/TaskExtensions.cs
@@ -50,7 +50,7 @@ namespace NLog.Targets.Syslog.Extensions
             var tcs = new TaskCompletionSource<object>();
             try
             {
-                beginMethod(arg1, arg2, arg3, Callback(endMethod, tcs), null);
+                beginMethod(arg1, arg2, arg3, Callback(endMethod, tcs), state);
             }
             catch (Exception exception)
             {

--- a/src/NLog.Targets.Syslog/Extensions/TaskExtensions.cs
+++ b/src/NLog.Targets.Syslog/Extensions/TaskExtensions.cs
@@ -25,6 +25,26 @@ namespace NLog.Targets.Syslog.Extensions
                 .Unwrap();
         }
 
+        public static Task CanceledTask(this TaskCompletionSource<object> tcs)
+        {
+            tcs.SetCanceled();
+            return tcs.Task;
+        }
+
+        public static Task SucceededTask(this TaskCompletionSource<object> tcs, Action action = null)
+        {
+            action?.Invoke();
+            tcs.SetResult(null);
+            return tcs.Task;
+        }
+
+        public static Task FailedTask(this TaskCompletionSource<object> tcs, Exception exception, Action<Exception> action = null)
+        {
+            action?.Invoke(exception);
+            tcs.SetException(exception);
+            return tcs.Task;
+        }
+
         public static Task SafeFromAsync<TArg1, TArg2, TArg3>(this TaskFactory taskFactory, Func<TArg1, TArg2, TArg3, AsyncCallback, object, IAsyncResult> beginMethod, Action<IAsyncResult> endMethod, TArg1 arg1, TArg2 arg2, TArg3 arg3, object state)
         {
             try

--- a/src/NLog.Targets.Syslog/Extensions/TaskExtensions.cs
+++ b/src/NLog.Targets.Syslog/Extensions/TaskExtensions.cs
@@ -25,18 +25,6 @@ namespace NLog.Targets.Syslog.Extensions
                 .Unwrap();
         }
 
-        public static Task SafeFromAsync<TArg1, TArg2, TArg3>(this TaskFactory taskFactory, Func<TArg1, TArg2, TArg3, AsyncCallback, object, IAsyncResult> beginMethod, Action<IAsyncResult> endMethod, TArg1 arg1, TArg2 arg2, TArg3 arg3, object state)
-        {
-            try
-            {
-                return taskFactory.FromAsync(beginMethod, endMethod, arg1, arg2, arg3, state);
-            }
-            catch (Exception exception)
-            {
-                return new TaskCompletionSource<object>().FailedTask(exception);
-            }
-        }
-
         public static Task CanceledTask(this TaskCompletionSource<object> tcs)
         {
             tcs.SetCanceled();
@@ -55,6 +43,40 @@ namespace NLog.Targets.Syslog.Extensions
             action?.Invoke(exception);
             tcs.SetException(exception);
             return tcs.Task;
+        }
+
+        public static Task SafeFromAsync<TArg1, TArg2, TArg3>(this TaskFactory taskFactory, Func<TArg1, TArg2, TArg3, AsyncCallback, object, IAsyncResult> beginMethod, Action<IAsyncResult> endMethod, TArg1 arg1, TArg2 arg2, TArg3 arg3, object state)
+        {
+            var tcs = new TaskCompletionSource<object>();
+            try
+            {
+                beginMethod(arg1, arg2, arg3, Callback(endMethod, tcs), null);
+            }
+            catch (Exception exception)
+            {
+                tcs.SetException(exception);
+            }
+            return tcs.Task;
+        }
+
+        private static AsyncCallback Callback<TResult>(Action<IAsyncResult> endMethod, TaskCompletionSource<TResult> tcs)
+        {
+            return asyncResult =>
+            {
+                try
+                {
+                    endMethod(asyncResult);
+                    tcs.SetResult(default(TResult));
+                }
+                catch (OperationCanceledException)
+                {
+                    tcs.SetCanceled();
+                }
+                catch (Exception exception)
+                {
+                    tcs.SetException(exception);
+                }
+            };
         }
     }
 }

--- a/src/NLog.Targets.Syslog/Extensions/TaskExtensions.cs
+++ b/src/NLog.Targets.Syslog/Extensions/TaskExtensions.cs
@@ -24,5 +24,17 @@ namespace NLog.Targets.Syslog.Extensions
                 }, token, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Current)
                 .Unwrap();
         }
+
+        public static Task SafeFromAsync<TArg1, TArg2, TArg3>(this TaskFactory taskFactory, Func<TArg1, TArg2, TArg3, AsyncCallback, object, IAsyncResult> beginMethod, Action<IAsyncResult> endMethod, TArg1 arg1, TArg2 arg2, TArg3 arg3, object state)
+        {
+            try
+            {
+                return taskFactory.FromAsync(beginMethod, endMethod, arg1, arg2, arg3, state);
+            }
+            catch (Exception exception)
+            {
+                return new TaskCompletionSource<object>().FailedTask(exception);
+            }
+        }
     }
 }

--- a/src/NLog.Targets.Syslog/Extensions/TaskExtensions.cs
+++ b/src/NLog.Targets.Syslog/Extensions/TaskExtensions.cs
@@ -38,9 +38,8 @@ namespace NLog.Targets.Syslog.Extensions
             return tcs.Task;
         }
 
-        public static Task FailedTask(this TaskCompletionSource<object> tcs, Exception exception, Action<Exception> action = null)
+        public static Task FailedTask(this TaskCompletionSource<object> tcs, Exception exception)
         {
-            action?.Invoke(exception);
             tcs.SetException(exception);
             return tcs.Task;
         }

--- a/src/NLog.Targets.Syslog/LogEventMsgSet.cs
+++ b/src/NLog.Targets.Syslog/LogEventMsgSet.cs
@@ -57,7 +57,11 @@ namespace NLog.Targets.Syslog
                         if (t.IsCanceled)
                             return tcs.CanceledTask();
                         if (t.Exception != null)
-                            return tcs.FailedTask(t.Exception, exception => asyncLogEvent.Continuation(exception.GetBaseException()));
+                        {
+                            asyncLogEvent.Continuation(t.Exception.GetBaseException());
+                            tcs.SetException(t.Exception);
+                            return Task.FromResult<object>(null);
+                        }
                         return SendAsync(token, tcs);
                     }, token, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Current)
                     .Unwrap();

--- a/src/NLog.Targets.Syslog/MessageSend/Tcp.cs
+++ b/src/NLog.Targets.Syslog/MessageSend/Tcp.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Authentication;
-using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/NLog.Targets.Syslog/MessageSend/Tcp.cs
+++ b/src/NLog.Targets.Syslog/MessageSend/Tcp.cs
@@ -106,7 +106,7 @@ namespace NLog.Targets.Syslog.MessageSend
             var octetCount = message.Length;
             var prefix = new ASCIIEncoding().GetBytes($"{octetCount} ");
 
-            return Task.Factory.FromAsync(stream.BeginWrite, stream.EndWrite, prefix, 0, prefix.Length, null);
+            return Task.Factory.SafeFromAsync(stream.BeginWrite, stream.EndWrite, prefix, 0, prefix.Length, null);
         }
 
         private Task WriteAsync(int offset, ByteArray data, CancellationToken token)
@@ -119,7 +119,7 @@ namespace NLog.Targets.Syslog.MessageSend
             var count = isLastWrite ? toBeWrittenTotal : dataChunkSize;
 
             return Task.Factory
-                .FromAsync(stream.BeginWrite, stream.EndWrite, (byte[])data, offset, count, null)
+                .SafeFromAsync(stream.BeginWrite, stream.EndWrite, (byte[])data, offset, count, null)
                 .Then(task => isLastWrite ? task : WriteAsync(offset + dataChunkSize, data, token), token)
                 .Unwrap();
         }

--- a/src/NLog.Targets.Syslog/MessageSend/Tcp.cs
+++ b/src/NLog.Targets.Syslog/MessageSend/Tcp.cs
@@ -105,7 +105,6 @@ namespace NLog.Targets.Syslog.MessageSend
 
             var octetCount = message.Length;
             var prefix = new ASCIIEncoding().GetBytes($"{octetCount} ");
-
             return Task.Factory.SafeFromAsync(stream.BeginWrite, stream.EndWrite, prefix, 0, prefix.Length, null);
         }
 

--- a/src/NLog.Targets.Syslog/MessageSend/Tcp.cs
+++ b/src/NLog.Targets.Syslog/MessageSend/Tcp.cs
@@ -60,6 +60,9 @@ namespace NLog.Targets.Syslog.MessageSend
             DisposeTcpClientAndItsInnerStream();
 
             tcp = new TcpClient();
+            tcp.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ExclusiveAddressUse, true);
+            tcp.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.DontLinger, false);
+            tcp.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Linger, new LingerOption(true, 0));
             tcp.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
 
             return Task.FromResult<object>(null);
@@ -102,6 +105,7 @@ namespace NLog.Targets.Syslog.MessageSend
 
             var octetCount = message.Length;
             var prefix = new ASCIIEncoding().GetBytes($"{octetCount} ");
+
             return Task.Factory.FromAsync(stream.BeginWrite, stream.EndWrite, prefix, 0, prefix.Length, null);
         }
 

--- a/src/NLog.Targets.Syslog/Properties/AssemblyInfo.cs
+++ b/src/NLog.Targets.Syslog/Properties/AssemblyInfo.cs
@@ -10,4 +10,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("3.0.1")]
+[assembly: AssemblyVersion("3.0.2")]

--- a/src/NLog.Targets.Syslog/Settings/Rfc3164Config.cs
+++ b/src/NLog.Targets.Syslog/Settings/Rfc3164Config.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using NLog.Layouts;
 using System.Net;
 using NLog.Targets.Syslog.Extensions;

--- a/src/NLog.Targets.Syslog/Settings/Rfc5424Config.cs
+++ b/src/NLog.Targets.Syslog/Settings/Rfc5424Config.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using NLog.Layouts;
 using System.Net;
 using System.Net.NetworkInformation;

--- a/src/NLog.Targets.Syslog/SyslogTarget.cs
+++ b/src/NLog.Targets.Syslog/SyslogTarget.cs
@@ -88,7 +88,7 @@ namespace NLog.Targets.Syslog
             }
             catch (Exception ex)
             {
-                InternalLogger.Debug(ex, $"{GetType().Name} dispose error");
+                InternalLogger.Warn(ex, $"{GetType().Name} dispose error");
             }
         }
     }

--- a/src/TestApp/FormTest.Designer.cs
+++ b/src/TestApp/FormTest.Designer.cs
@@ -199,6 +199,7 @@ namespace TestApp
             Name = "FormTest";
             StartPosition = FormStartPosition.CenterScreen;
             Text = "Syslog Target Demo";
+            this.FormClosing += new FormClosingEventHandler(OnFormClosing);
             ResumeLayout(false);
         }
     }

--- a/src/TestApp/FormTest.cs
+++ b/src/TestApp/FormTest.cs
@@ -231,5 +231,10 @@ namespace TestApp
             Action enableButton = () => buttonStartStopSyslogServer.Enabled = true;
             Task.Delay(500).ContinueWith(_ => Invoke(enableButton));
         }
+
+        private void OnFormClosing(object sender, FormClosingEventArgs e)
+        {
+            syslogServer.Dispose();
+        }
     }
 }

--- a/src/TestApp/FormTest.cs
+++ b/src/TestApp/FormTest.cs
@@ -1,7 +1,9 @@
 ﻿using NLog;
 using NLog.Common;
 using System;
+using System.Collections.ObjectModel;
 using System.Configuration;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -36,8 +38,19 @@ namespace TestApp
 
         public FormTest()
         {
+            TaskScheduler.UnobservedTaskException += HandleUnobservedTaskException;
             InitializeComponent();
             InitSyslogServer();
+        }
+
+        private static void HandleUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
+        {
+            e.SetObserved();
+            foreach (var innerException in e.Exception.Flatten().InnerExceptions)
+            {
+                Trace.WriteLine("******************** DANGEROUSLY UNOBSERVED TASK EXCEPTION!!!");
+                Trace.WriteLine(innerException);
+            }
         }
 
         private void InitSyslogServer()

--- a/src/TestApp/FormTest.cs
+++ b/src/TestApp/FormTest.cs
@@ -1,7 +1,6 @@
 ﻿using NLog;
 using NLog.Common;
 using System;
-using System.Collections.ObjectModel;
 using System.Configuration;
 using System.Diagnostics;
 using System.IO;

--- a/src/TestApp/ServerSocket.cs
+++ b/src/TestApp/ServerSocket.cs
@@ -38,6 +38,14 @@ namespace TestApp
 
         protected abstract void Receive();
 
+        public void StopListening()
+        {
+            if (!KeepGoing)
+                return;
+            KeepGoing = false;
+            BoundSocket.Dispose();
+        }
+
         public void Dispose()
         {
             Dispose(true);
@@ -47,8 +55,7 @@ namespace TestApp
         {
             if (!disposing)
                 return;
-            KeepGoing = false;
-            BoundSocket.Dispose();
+            StopListening();
         }
     }
 }

--- a/src/TestApp/StateObject.cs
+++ b/src/TestApp/StateObject.cs
@@ -51,5 +51,10 @@ namespace TestApp
         {
             return receiveSocket.EndReceive(asyncResult);
         }
+
+        public void Dispose()
+        {
+            receiveSocket.Dispose();
+        }
     }
 }

--- a/src/TestApp/SyslogServer.cs
+++ b/src/TestApp/SyslogServer.cs
@@ -52,6 +52,13 @@ namespace TestApp
                 return;
 
             stopped = true;
+            udpServer.StopListening();
+            tcpServer.StopListening();
+        }
+
+        public void Dispose()
+        {
+            Stop();
             udpServer.Dispose();
             tcpServer.Dispose();
         }

--- a/src/TestApp/TcpServer.cs
+++ b/src/TestApp/TcpServer.cs
@@ -8,13 +8,14 @@ namespace TestApp
     internal class TcpServer: ServerSocket
     {
         private const int DefaultListeningSocketBacklog = 1000;
-        private static readonly ManualResetEvent Signal = new ManualResetEvent(false);
+        private readonly ManualResetEvent signal;
         private readonly int listeningSocketBacklog;
 
         public TcpServer(int socketBacklog = 0)
         {
             ProtocolType = ProtocolType.Tcp;
             SocketType = SocketType.Stream;
+            signal = new ManualResetEvent(false);
             listeningSocketBacklog = socketBacklog == 0 ? DefaultListeningSocketBacklog : socketBacklog;
         }
 
@@ -29,9 +30,9 @@ namespace TestApp
             if (!KeepGoing)
                 return;
 
-            Signal.Reset();
+            signal.Reset();
             BoundSocket.BeginAccept(AcceptCallback, BoundSocket);
-            Signal.WaitOne();
+            signal.WaitOne();
         }
 
         private void AcceptCallback(IAsyncResult asyncResult)
@@ -39,7 +40,7 @@ namespace TestApp
             if (!KeepGoing)
                 return;
 
-            Signal.Set();
+            signal.Set();
             var boundSocket = (Socket)asyncResult.AsyncState;
             var receivingSocket = boundSocket.EndAccept(asyncResult);
             var state = new TcpState(receivingSocket);
@@ -59,7 +60,7 @@ namespace TestApp
         {
             base.Dispose(disposing);
             if (disposing)
-                Signal.Dispose();
+                signal.Dispose();
         }
     }
 }

--- a/src/TestApp/TcpServer.cs
+++ b/src/TestApp/TcpServer.cs
@@ -49,10 +49,14 @@ namespace TestApp
 
         private void ReadCallback(IAsyncResult asyncResult)
         {
-            if (!KeepGoing)
-                return;
-
             var state = (TcpState)asyncResult.AsyncState;
+
+            if (!KeepGoing)
+            {
+                state.Dispose();
+                return;
+            }
+
             state.EndReceive(asyncResult, ReadCallback, OnReceivedString);
         }
 

--- a/src/TestApp/UdpServer.cs
+++ b/src/TestApp/UdpServer.cs
@@ -6,12 +6,13 @@ namespace TestApp
 {
     internal class UdpServer: ServerSocket
     {
-        private static readonly ManualResetEvent Signal = new ManualResetEvent(false);
+        private readonly ManualResetEvent signal;
 
         public UdpServer()
         {
             ProtocolType = ProtocolType.Udp;
             SocketType = SocketType.Dgram;
+            signal = new ManualResetEvent(false);
         }
 
         protected override void Receive()
@@ -19,10 +20,10 @@ namespace TestApp
             if (!KeepGoing)
                 return;
 
-            Signal.Reset();
+            signal.Reset();
             var state = new UdpState(BoundSocket);
             state.BeginReceive(ReadCallback);
-            Signal.WaitOne();
+            signal.WaitOne();
         }
 
         private void ReadCallback(IAsyncResult asyncResult)
@@ -30,7 +31,7 @@ namespace TestApp
             if (!KeepGoing)
                 return;
 
-            Signal.Set();
+            signal.Set();
             var state = (UdpState)asyncResult.AsyncState;
             state.EndReceive(asyncResult, ReadCallback, OnReceivedString);
         }
@@ -38,7 +39,7 @@ namespace TestApp
         protected override void Dispose(bool disposing)
         {
             if (disposing)
-                Signal.Dispose();
+                signal.Dispose();
             base.Dispose(disposing);
         }
     }

--- a/src/TestApp/UdpServer.cs
+++ b/src/TestApp/UdpServer.cs
@@ -28,11 +28,15 @@ namespace TestApp
 
         private void ReadCallback(IAsyncResult asyncResult)
         {
+            var state = (UdpState)asyncResult.AsyncState;
+
             if (!KeepGoing)
+            {
+                state.Dispose();
                 return;
+            }
 
             signal.Set();
-            var state = (UdpState)asyncResult.AsyncState;
             state.EndReceive(asyncResult, ReadCallback, OnReceivedString);
         }
 

--- a/src/TestApp/app.config
+++ b/src/TestApp/app.config
@@ -11,7 +11,4 @@
         <add key="MessagesFromFileLogLevel" value="Info" />
         <add key="MessagesFromFileFilePath" value="./messagesToLog.txt" />
     </appSettings>
-    <runtime>
-        <ThrowUnobservedTaskExceptions enabled="true"/>
-    </runtime>
 </configuration>

--- a/src/TestApp/app.config
+++ b/src/TestApp/app.config
@@ -11,4 +11,7 @@
         <add key="MessagesFromFileLogLevel" value="Info" />
         <add key="MessagesFromFileFilePath" value="./messagesToLog.txt" />
     </appSettings>
+    <runtime>
+        <ThrowUnobservedTaskExceptions enabled="true"/>
+    </runtime>
 </configuration>


### PR DESCRIPTION
Fix issues when the Syslog server is down:
- exceptions thrown outside continuations
- stream/socket related exceptions not resulting in faulted Tasks
- UnobservedTaskException events due to a wrong usage of TaskCompletionSource