### PR TITLE
AppVeyor support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,12 @@
-version: 1.0.{build}
+version: 3.0.2.{build}
 configuration: Release
 platform: Any CPU
 before_build:
-- cmd: nuget restore src/NLog.Targets.Syslog.sln -DisableParallelProcessing
+  - cmd: nuget restore src/NLog.Targets.Syslog.sln -DisableParallelProcessing
 build:
   project: src/NLog.Targets.Syslog.sln
   verbosity: minimal
 after_build:
-- cmd: nuget pack src/NLog.Targets.Syslog/NLog.Targets.Syslog.csproj -Prop Configuration=Release -Prop Platform=AnyCPU
+  - cmd: nuget pack src/NLog.Targets.Syslog/NLog.Targets.Syslog.csproj -Prop Configuration=Release -Prop Platform=AnyCPU
 artifacts:
-- path: NLog.Targets.Syslog*.nupkg
+  - path: NLog.Targets.Syslog*.nupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,12 @@
+version: 1.0.{build}
+configuration: Release
+platform: Any CPU
+before_build:
+- cmd: nuget restore src/NLog.Targets.Syslog.sln -DisableParallelProcessing
+build:
+  project: src/NLog.Targets.Syslog.sln
+  verbosity: minimal
+after_build:
+- cmd: nuget pack src/NLog.Targets.Syslog/NLog.Targets.Syslog.csproj -Prop Configuration=Release -Prop Platform=AnyCPU
+artifacts:
+- path: NLog.Targets.Syslog*.nupkg


### PR DESCRIPTION
I saw this project isn't running on a build server. AppVeyor is a free (for OSS) buildserver for .NET 

At NLog we are very happy with AppVeyor. Therefor I prepared the project for AppVeyor:

- enabled nuget package restore
- enabled nuget package building (

See result for my fork: https://ci.appveyor.com/project/304NotModified/nlog-targets-syslog/build/1.0.8

To set-up AppVeyor:

1. login with AppVeyor (with GitHub account)
2. create new project
3. select this repos.
4. Done

After this, every PR will be automatically build by AppVeyor. 

In the future you could add some unit tests which will be also run by AppVeyor