### PR TITLE
Fix issue with ASP.Net projects

### DIFF
--- a/src/NLog.Targets.Syslog/Extensions/StackTraceExtensions.cs
+++ b/src/NLog.Targets.Syslog/Extensions/StackTraceExtensions.cs
@@ -16,14 +16,12 @@ namespace NLog.Targets.Syslog.Extensions
             return stackTrace
                 .GetFrames()
                 ?.Select(x => x.GetMethod().DeclaringType?.Assembly)
-                .Where(x => x != null)
-                .SkipWhile(NotNLog)
                 .First(NotNLog);
         }
 
         private static bool NotNLog(Assembly x)
         {
-            return x.GetName().Name != NLogAssemblyName;
+            return x != null && !x.GetName().Name.Contains(NLogAssemblyName);
         }
     }
 }


### PR DESCRIPTION
ASP.Net project were not able to properly get assembly info.  This will ensure no exception occurs when there is nothing returned from the list.