### PR TITLE
Handle config changes

### DIFF
--- a/src/NLog.Targets.Syslog/NLog.Targets.Syslog.csproj
+++ b/src/NLog.Targets.Syslog/NLog.Targets.Syslog.csproj
@@ -51,6 +51,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Extensions\AssemblyExtensions.cs" />
+    <Compile Include="Settings\NotifyPropertyChanged.cs" />
     <Compile Include="Settings\UniversalAssembly.cs" />
     <Compile Include="Extensions\AsyncLogEventInfoExtensions.cs" />
     <Compile Include="AsyncLogger.cs" />

--- a/src/NLog.Targets.Syslog/Properties/AssemblyInfo.cs
+++ b/src/NLog.Targets.Syslog/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright © 2013 - present by Jesper Hess Nielsen, Luigi Berrettini and others: https://github.com/graffen/NLog.Targets.Syslog/graphs/contributors")]
 [assembly: ComVisible(false)]
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.1.1.0")]
-[assembly: AssemblyInformationalVersion("3.1.1")]
+[assembly: AssemblyFileVersion("3.1.2.0")]
+[assembly: AssemblyInformationalVersion("3.1.2")]

--- a/src/NLog.Targets.Syslog/Settings/EnforcementConfig.cs
+++ b/src/NLog.Targets.Syslog/Settings/EnforcementConfig.cs
@@ -2,44 +2,83 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.ComponentModel;
 
 namespace NLog.Targets.Syslog.Settings
 {
     /// <summary>Enforcement configuration</summary>
-    public class EnforcementConfig
+    public class EnforcementConfig : NotifyPropertyChanged, IDisposable
     {
+        private ThrottlingConfig throttling;
+        private readonly PropertyChangedEventHandler throttlingPropsChanged;
         private int messageProcessors;
+        private bool splitOnNewLine;
+        private bool transliterate;
+        private bool replaceInvalidCharacters;
+        private bool truncateFieldsToMaxLength;
+        private long truncateMessageTo;
 
         /// <summary>Throttling to be triggered when a configured number of log entries are waiting to be processed</summary>
-        public ThrottlingConfig Throttling { get; set; }
+        public ThrottlingConfig Throttling
+        {
+            get { return throttling; }
+            set { SetProperty(ref throttling, value); }
+        }
 
         /// <summary>The amount of parallel message processors</summary>
         public int MessageProcessors
         {
             get { return messageProcessors; }
-            set { messageProcessors = value <= 0 ? Environment.ProcessorCount : value; }
+            set { SetProperty(ref messageProcessors, value <= 0 ? Environment.ProcessorCount : value); }
         }
 
         /// <summary>Whether or not to split each log entry by newlines and send each line separately</summary>
-        public bool SplitOnNewLine { get; set; }
+        public bool SplitOnNewLine
+        {
+            get { return splitOnNewLine; }
+            set { SetProperty(ref splitOnNewLine, value); }
+        }
 
         /// <summary>Whether or not to transliterate from Unicode to ASCII</summary>
-        public bool Transliterate { get; set; }
+        public bool Transliterate
+        {
+            get { return transliterate; }
+            set { SetProperty(ref transliterate, value); }
+        }
 
         /// <summary>Whether or not to replace invalid characters on the basis of RFC rules</summary>
-        public bool ReplaceInvalidCharacters { get; set; }
+        public bool ReplaceInvalidCharacters
+        {
+            get { return replaceInvalidCharacters; }
+            set { SetProperty(ref replaceInvalidCharacters, value); }
+        }
 
         /// <summary>Whether or not to truncate fields to the max length specified in RFCs</summary>
-        public bool TruncateFieldsToMaxLength { get; set; }
+        public bool TruncateFieldsToMaxLength
+        {
+            get { return truncateFieldsToMaxLength; }
+            set { SetProperty(ref truncateFieldsToMaxLength, value); }
+        }
 
         /// <summary>The length to truncate the Syslog message to or zero</summary>
-        public long TruncateMessageTo { get; set; }
+        public long TruncateMessageTo
+        {
+            get { return truncateMessageTo; }
+            set { SetProperty(ref truncateMessageTo, value); }
+        }
 
         /// <summary>Builds a new instance of the EnforcementConfig class</summary>
         public EnforcementConfig()
         {
-            MessageProcessors = 1;
-            Throttling = new ThrottlingConfig();
+            throttling = new ThrottlingConfig();
+            throttlingPropsChanged = (sender, args) => OnPropertyChanged(nameof(Throttling));
+            throttling.PropertyChanged += throttlingPropsChanged;
+            messageProcessors = 1;
+        }
+
+        public void Dispose()
+        {
+            throttling.PropertyChanged -= throttlingPropsChanged;
         }
     }
 }

--- a/src/NLog.Targets.Syslog/Settings/KeepAliveConfig.cs
+++ b/src/NLog.Targets.Syslog/Settings/KeepAliveConfig.cs
@@ -5,27 +5,42 @@ namespace NLog.Targets.Syslog.Settings
 {
     /// <summary>KeepAlive configuration</summary>
     /// <remarks>The number of keep-alive probes (data retransmissions) is set to 10 and cannot be changed</remarks>
-    public class KeepAliveConfig
+    public class KeepAliveConfig : NotifyPropertyChanged
     {
         private const int DefaultTimeout = 5000;
         private const int DefaultInterval = 1000;
+        private bool enabled;
+        private int timeout;
+        private int interval;
 
         /// <summary>Whether to use keep-alive or not</summary>
-        public bool Enabled { get; set; }
+        public bool Enabled
+        {
+            get { return enabled; }
+            set { SetProperty(ref enabled, value); }
+        }
 
         /// <summary>The timeout, in milliseconds, with no activity until the first keep-alive packet is sent</summary>
         /// <remarks>The default value, on TCP socket initialization, is 2 hours</remarks>
-        public int Timeout { get; set; }
+        public int Timeout
+        {
+            get { return timeout; }
+            set { SetProperty(ref timeout, value); }
+        }
 
         /// <summary>The interval, in milliseconds, between when successive keep-alive packets are sent if no acknowledgement is received</summary>
         /// <remarks>The default value, on TCP socket initialization, is 1 second</remarks>
-        public int Interval { get; set; }
+        public int Interval
+        {
+            get { return interval; }
+            set { SetProperty(ref interval, value); }
+        }
 
         public KeepAliveConfig()
         {
-            Enabled = true;
-            Timeout = DefaultTimeout;
-            Interval = DefaultInterval;
+            enabled = true;
+            timeout = DefaultTimeout;
+            interval = DefaultInterval;
         }
     }
 }

--- a/src/NLog.Targets.Syslog/Settings/MessageBuilderConfig.cs
+++ b/src/NLog.Targets.Syslog/Settings/MessageBuilderConfig.cs
@@ -1,29 +1,67 @@
 // Licensed under the BSD license
 // See the LICENSE file in the project root for more information
 
+using System;
+using System.ComponentModel;
+
 namespace NLog.Targets.Syslog.Settings
 {
     /// <summary>Message build configuration</summary>
-    public class MessageBuilderConfig
+    public class MessageBuilderConfig : NotifyPropertyChanged, IDisposable
     {
+        private Facility facility;
+        private RfcNumber rfc;
+        private Rfc3164Config rfc3164;
+        private readonly PropertyChangedEventHandler rfc3164PropsChanged;
+        private Rfc5424Config rfc5424;
+        private readonly PropertyChangedEventHandler rfc5424PropsChanged;
+
         /// <summary>The Syslog facility to log from (its name e.g. local0 or local7)</summary>
-        public Facility Facility { get; set; }
+        public Facility Facility
+        {
+            get { return facility; }
+            set { SetProperty(ref facility, value); }
+        }
 
         /// <summary>The Syslog protocol RFC to be followed</summary>
-        public RfcNumber Rfc { get; set; }
+        public RfcNumber Rfc
+        {
+            get { return rfc; }
+            set { SetProperty(ref rfc, value); }
+        }
 
         /// <summary>RFC 3164 related fields</summary>
-        public Rfc3164Config Rfc3164 { get; set; }
+        public Rfc3164Config Rfc3164
+        {
+            get { return rfc3164; }
+            set { SetProperty(ref rfc3164, value); }
+        }
 
         /// <summary>RFC 5424 related fields</summary>
-        public Rfc5424Config Rfc5424 { get; set; }
+        public Rfc5424Config Rfc5424
+        {
+            get { return rfc5424; }
+            set { SetProperty(ref rfc5424, value); }
+        }
 
         /// <summary>Builds a new instance of the MessageBuilderConfig class</summary>
         public MessageBuilderConfig()
         {
-            Rfc = RfcNumber.Rfc5424;
-            Rfc3164 = new Rfc3164Config();
-            Rfc5424 = new Rfc5424Config();
+            rfc = RfcNumber.Rfc5424;
+            rfc3164 = new Rfc3164Config();
+            rfc3164PropsChanged = (sender, args) => OnPropertyChanged(nameof(Rfc3164));
+            rfc3164.PropertyChanged += rfc3164PropsChanged;
+
+            rfc5424 = new Rfc5424Config();
+            rfc5424PropsChanged = (sender, args) => OnPropertyChanged(nameof(Rfc5424));
+            rfc5424.PropertyChanged += rfc5424PropsChanged;
+        }
+
+        public void Dispose()
+        {
+            rfc3164.PropertyChanged -= rfc3164PropsChanged;
+            rfc5424.PropertyChanged -= rfc5424PropsChanged;
+            rfc5424.Dispose();
         }
     }
 }

--- a/src/NLog.Targets.Syslog/Settings/MessageTransmitterConfig.cs
+++ b/src/NLog.Targets.Syslog/Settings/MessageTransmitterConfig.cs
@@ -1,25 +1,58 @@
 // Licensed under the BSD license
 // See the LICENSE file in the project root for more information
 
+using System;
+using System.ComponentModel;
+
 namespace NLog.Targets.Syslog.Settings
 {
     /// <summary>Message transmission configuration</summary>
-    public class MessageTransmitterConfig
+    public class MessageTransmitterConfig : NotifyPropertyChanged, IDisposable
     {
+        private ProtocolType protocol;
+        private UdpConfig udp;
+        private readonly PropertyChangedEventHandler udpPropsChanged;
+        private TcpConfig tcp;
+        private readonly PropertyChangedEventHandler tcpPropsChanged;
+
         /// <summary>The Syslog server protocol</summary>
-        public ProtocolType Protocol { get; set; }
+        public ProtocolType Protocol
+        {
+            get { return protocol; }
+            set { SetProperty(ref protocol, value); }
+        }
 
         /// <summary>UDP related fields</summary>
-        public UdpConfig Udp { get; set; }
+        public UdpConfig Udp
+        {
+            get { return udp; }
+            set { SetProperty(ref udp, value); }
+        }
 
         /// <summary>TCP related fields</summary>
-        public TcpConfig Tcp { get; set; }
+        public TcpConfig Tcp
+        {
+            get { return tcp; }
+            set { SetProperty(ref tcp, value); }
+        }
 
         /// <summary>Builds a new instance of the MessageTransmitterConfig class</summary>
         public MessageTransmitterConfig()
         {
-            Udp = new UdpConfig();
-            Tcp = new TcpConfig();
+            udp = new UdpConfig();
+            udpPropsChanged = (sender, args) => OnPropertyChanged(nameof(Udp));
+            udp.PropertyChanged += udpPropsChanged;
+
+            tcp = new TcpConfig();
+            tcpPropsChanged = (sender, args) => OnPropertyChanged(nameof(Tcp));
+            tcp.PropertyChanged += tcpPropsChanged;
+        }
+
+        public void Dispose()
+        {
+            udp.PropertyChanged -= udpPropsChanged;
+            tcp.PropertyChanged -= tcpPropsChanged;
+            tcp.Dispose();
         }
     }
 }

--- a/src/NLog.Targets.Syslog/Settings/NotifyPropertyChanged.cs
+++ b/src/NLog.Targets.Syslog/Settings/NotifyPropertyChanged.cs
@@ -1,0 +1,44 @@
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace NLog.Targets.Syslog.Settings
+{
+    /// <summary>Implementation of <see cref="INotifyPropertyChanged" /> to simplify config settings</summary>
+    public abstract class NotifyPropertyChanged : INotifyPropertyChanged
+    {
+        /// <summary>Multicast event for property change notifications</summary>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected bool SetProperty<T>(ref T oldValue, T newValue, [CallerMemberName] string propertyName = null)
+        {
+            if (Equals(oldValue, newValue))
+            {
+                return false;
+            }
+
+            oldValue = newValue;
+            OnPropertyChanged(propertyName);
+            return true;
+        }
+
+        protected void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        protected NotifyCollectionChangedEventHandler CollectionChangedFactory(PropertyChangedEventHandler onElemPropsChanged)
+        {
+            return (sender, eventArgs) =>
+            {
+                if (eventArgs.NewItems != null)
+                    foreach (INotifyPropertyChanged item in eventArgs.NewItems)
+                        item.PropertyChanged += onElemPropsChanged;
+
+                if (eventArgs.OldItems != null)
+                    foreach (INotifyPropertyChanged item in eventArgs.OldItems)
+                        item.PropertyChanged -= onElemPropsChanged;
+            };
+        }
+    }
+}

--- a/src/NLog.Targets.Syslog/Settings/Rfc3164Config.cs
+++ b/src/NLog.Targets.Syslog/Settings/Rfc3164Config.cs
@@ -2,25 +2,36 @@
 // See the LICENSE file in the project root for more information
 
 using NLog.Layouts;
-using System.Net;
 using NLog.Targets.Syslog.Extensions;
+using System.Net;
 
 namespace NLog.Targets.Syslog.Settings
 {
     /// <summary>RFC 3164 configuration</summary>
-    public class Rfc3164Config
+    public class Rfc3164Config : NotifyPropertyChanged
     {
+        private Layout hostname;
+        private Layout tag;
+
         /// <summary>The HOSTNAME field of the HEADER part</summary>
-        public Layout Hostname { get; set; }
+        public Layout Hostname
+        {
+            get { return hostname; }
+            set { SetProperty(ref hostname, value); }
+        }
 
         /// <summary>The TAG field of the MSG part</summary>
-        public Layout Tag { get; set; }
+        public Layout Tag
+        {
+            get { return tag; }
+            set { SetProperty(ref tag, value); }
+        }
 
         /// <summary>Builds a new instance of the Rfc3164 class</summary>
         public Rfc3164Config()
         {
-            Hostname = Dns.GetHostName();
-            Tag = UniversalAssembly.EntryAssembly().Name();
+            hostname = Dns.GetHostName();
+            tag = UniversalAssembly.EntryAssembly().Name();
         }
     }
 }

--- a/src/NLog.Targets.Syslog/Settings/Rfc5424Config.cs
+++ b/src/NLog.Targets.Syslog/Settings/Rfc5424Config.cs
@@ -2,17 +2,26 @@
 // See the LICENSE file in the project root for more information
 
 using NLog.Layouts;
+using NLog.Targets.Syslog.Extensions;
+using System;
+using System.ComponentModel;
 using System.Net;
 using System.Net.NetworkInformation;
-using NLog.Targets.Syslog.Extensions;
 
 namespace NLog.Targets.Syslog.Settings
 {
     /// <summary>RFC 5424 configuration</summary>
-    public class Rfc5424Config
+    public class Rfc5424Config : NotifyPropertyChanged, IDisposable
     {
         private const string DefaultVersion = "1";
         private const string NilValue = "-";
+        private Layout hostname;
+        private Layout appName;
+        private Layout procId;
+        private Layout msgId;
+        private StructuredDataConfig structuredData;
+        private readonly PropertyChangedEventHandler structuredDataPropsChanged;
+        private bool disableBom;
 
         /// <summary>The VERSION field of the HEADER part</summary>
         public string Version { get; }
@@ -21,39 +30,71 @@ namespace NLog.Targets.Syslog.Settings
         public string DefaultHostname { get; }
 
         /// <summary>The HOSTNAME field of the HEADER part</summary>
-        public Layout Hostname { get; set; }
+        public Layout Hostname
+        {
+            get { return hostname; }
+            set { SetProperty(ref hostname, value); }
+        }
 
         /// <summary>The default APPNAME if no value is provided</summary>
         public string DefaultAppName { get; }
 
         /// <summary>The APPNAME field of the HEADER part</summary>
-        public Layout AppName { get; set; }
+        public Layout AppName
+        {
+            get { return appName; }
+            set { SetProperty(ref appName, value); }
+        }
 
         /// <summary>The PROCID field of the HEADER part</summary>
-        public Layout ProcId { get; set; }
+        public Layout ProcId
+        {
+            get { return procId; }
+            set { SetProperty(ref procId, value); }
+        }
 
         /// <summary>The MSGID field of the HEADER part</summary>
-        public Layout MsgId { get; set; }
+        public Layout MsgId
+        {
+            get { return msgId; }
+            set { SetProperty(ref msgId, value); }
+        }
 
         /// <summary>The STRUCTURED-DATA part</summary>
-        public StructuredDataConfig StructuredData { get; set; }
+        public StructuredDataConfig StructuredData
+        {
+            get { return structuredData; }
+            set { SetProperty(ref structuredData, value); }
+        }
 
         /// <summary>Whether to remove or not BOM in the MSG part</summary>
         /// <see href="https://github.com/rsyslog/rsyslog/issues/284">RSyslog issue #284</see>
-        public bool DisableBom { get; set; }
+        public bool DisableBom
+        {
+            get { return disableBom; }
+            set { SetProperty(ref disableBom, value); }
+        }
 
         /// <summary>Builds a new instance of the Rfc5424 class</summary>
         public Rfc5424Config()
         {
-            DefaultHostname = HostFqdn();
-            DefaultAppName = UniversalAssembly.EntryAssembly().Name();
             Version = DefaultVersion;
-            Hostname = DefaultHostname;
-            AppName = DefaultAppName;
-            ProcId = NilValue;
-            MsgId = NilValue;
-            StructuredData = new StructuredDataConfig();
-            DisableBom = false;
+            DefaultHostname = HostFqdn();
+            hostname = DefaultHostname;
+            DefaultAppName = UniversalAssembly.EntryAssembly().Name();
+            appName = DefaultAppName;
+            procId = NilValue;
+            msgId = NilValue;
+            structuredData = new StructuredDataConfig();
+            structuredDataPropsChanged = (sender, args) => OnPropertyChanged(nameof(StructuredData));
+            structuredData.PropertyChanged += structuredDataPropsChanged;
+            disableBom = false;
+        }
+
+        public void Dispose()
+        {
+            structuredData.PropertyChanged -= structuredDataPropsChanged;
+            structuredData.Dispose();
         }
 
         private static string HostFqdn()

--- a/src/NLog.Targets.Syslog/Settings/SdElementConfig.cs
+++ b/src/NLog.Targets.Syslog/Settings/SdElementConfig.cs
@@ -1,26 +1,52 @@
 // Licensed under the BSD license
 // See the LICENSE file in the project root for more information
 
-using System.Collections.Generic;
 using NLog.Config;
+using NLog.Targets.Syslog.Extensions;
+using System;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
 
 namespace NLog.Targets.Syslog.Settings
 {
     /// <summary>Syslog SD-ELEMENT field configuration</summary>
-    public class SdElementConfig
+    public class SdElementConfig : NotifyPropertyChanged, IDisposable
     {
+        private SdIdConfig sdId;
+        private ObservableCollection<SdParamConfig> sdParams;
+        private readonly PropertyChangedEventHandler sdParamPropsChanged;
+        private readonly NotifyCollectionChangedEventHandler sdParamsCollectionChanged;
+
         /// <summary>The SD-ID field of an SD-ELEMENT field in the STRUCTURED-DATA part</summary>
-        public SdIdConfig SdId { get; set; }
+        public SdIdConfig SdId
+        {
+            get { return sdId; }
+            set { SetProperty(ref sdId, value); }
+        }
 
         /// <summary>The SD-PARAM fields belonging to an SD-ELEMENT field in the STRUCTURED-DATA part</summary>
         [ArrayParameter(typeof(SdParamConfig), "SdParam")]
-        public IList<SdParamConfig> SdParams { get; set; }
+        public ObservableCollection<SdParamConfig> SdParams
+        {
+            get { return sdParams; }
+            set { SetProperty(ref sdParams, value); }
+        }
 
         /// <summary>Builds a new instance of the SdElement class</summary>
         public SdElementConfig()
         {
-            SdId = new SdIdConfig();
-            SdParams = new List<SdParamConfig>();
+            sdId = new SdIdConfig();
+            sdParams = new ObservableCollection<SdParamConfig>();
+            sdParamPropsChanged = (s, a) => OnPropertyChanged(nameof(SdParams));
+            sdParamsCollectionChanged = CollectionChangedFactory(sdParamPropsChanged);
+            sdParams.CollectionChanged += sdParamsCollectionChanged;
+        }
+
+        public void Dispose()
+        {
+            sdParams.ForEach(x => x.PropertyChanged -= sdParamPropsChanged);
+            sdParams.CollectionChanged -= sdParamsCollectionChanged;
         }
     }
 }

--- a/src/NLog.Targets.Syslog/Settings/SdParamConfig.cs
+++ b/src/NLog.Targets.Syslog/Settings/SdParamConfig.cs
@@ -6,12 +6,23 @@ using NLog.Layouts;
 namespace NLog.Targets.Syslog.Settings
 {
     /// <summary>Syslog SD-PARAM field configuration</summary>
-    public class SdParamConfig
+    public class SdParamConfig : NotifyPropertyChanged
     {
+        private Layout name;
+        private Layout value;
+
         /// <summary>The PARAM-NAME field of this SD-PARAM</summary>
-        public Layout Name { get; set; }
+        public Layout Name
+        {
+            get { return name; }
+            set { SetProperty(ref name, value); }
+        }
 
         /// <summary>The PARAM-VALUE field of this SD-PARAM</summary>
-        public Layout Value { get; set; }
+        public Layout Value
+        {
+            get { return value; }
+            set { SetProperty(ref this.value, value); }
+        }
     }
 }

--- a/src/NLog.Targets.Syslog/Settings/StructuredDataConfig.cs
+++ b/src/NLog.Targets.Syslog/Settings/StructuredDataConfig.cs
@@ -1,27 +1,57 @@
 // Licensed under the BSD license
 // See the LICENSE file in the project root for more information
 
-using System.Collections.Generic;
 using NLog.Config;
 using NLog.Layouts;
+using NLog.Targets.Syslog.Extensions;
+using System;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
 
 namespace NLog.Targets.Syslog.Settings
 {
     /// <summary>Syslog STRUCTURED-DATA part configuration</summary>
-    public class StructuredDataConfig
+    public class StructuredDataConfig : NotifyPropertyChanged, IDisposable
     {
+        private Layout fromEventProperties;
+        private ObservableCollection<SdElementConfig> sdElements;
+        private readonly PropertyChangedEventHandler sdElementPropsChanged;
+        private readonly NotifyCollectionChangedEventHandler sdElementsCollectionChanged;
+
         /// <summary>Allows to use log event properties data enabling different STRUCTURED-DATA for each log message</summary>
-        public Layout FromEventProperties { get; set; }
+        public Layout FromEventProperties
+        {
+            get { return fromEventProperties; }
+            set { SetProperty(ref fromEventProperties, value); }
+        }
 
         /// <summary>The SD-ELEMENTs contained in the STRUCTURED-DATA part</summary>
         [ArrayParameter(typeof(SdElementConfig), "SdElement")]
-        public IList<SdElementConfig> SdElements { get; set; }
+        public ObservableCollection<SdElementConfig> SdElements
+        {
+            get { return sdElements; }
+            set { SetProperty(ref sdElements, value); }
+        }
 
         /// <summary>Builds a new instance of the StructuredData class</summary>
         public StructuredDataConfig()
         {
-            FromEventProperties = string.Empty;
-            SdElements = new List<SdElementConfig>();
+            fromEventProperties = string.Empty;
+            sdElements = new ObservableCollection<SdElementConfig>();
+            sdElementPropsChanged = (s, a) => OnPropertyChanged(nameof(SdElements));
+            sdElementsCollectionChanged = CollectionChangedFactory(sdElementPropsChanged);
+            sdElements.CollectionChanged += sdElementsCollectionChanged;
+        }
+
+        public void Dispose()
+        {
+            sdElements.ForEach(x =>
+            {
+                x.PropertyChanged -= sdElementPropsChanged;
+                x.Dispose();
+            });
+            sdElements.CollectionChanged -= sdElementsCollectionChanged;
         }
     }
 }

--- a/src/NLog.Targets.Syslog/Settings/TcpConfig.cs
+++ b/src/NLog.Targets.Syslog/Settings/TcpConfig.cs
@@ -2,64 +2,103 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.ComponentModel;
 
 namespace NLog.Targets.Syslog.Settings
 {
     /// <summary>TCP configuration</summary>
-    public class TcpConfig
+    public class TcpConfig : NotifyPropertyChanged, IDisposable
     {
         private const string Localhost = "localhost";
         private const int DefaultPort = 514;
         private const int DefaultReconnectInterval = 500;
         private const int DefaultConnectionCheckTimeout = 500000;
         private const int DefaultBufferSize = 4096;
-        private FramingMethod framing;
+        private string server;
+        private int port;
         private TimeSpan recoveryTime;
+        private KeepAliveConfig keepAlive;
+        private readonly PropertyChangedEventHandler keepAlivePropsChanged;
+        private int connectionCheckTimeout;
+        private bool useTls;
+        private FramingMethod framing;
+        private int dataChunkSize;
 
         /// <summary>The IP address or hostname of the Syslog server</summary>
-        public string Server { get; set; }
+        public string Server
+        {
+            get { return server; }
+            set { SetProperty(ref server, value); }
+        }
 
         /// <summary>The port number the Syslog server is listening on</summary>
-        public int Port { get; set; }
+        public int Port
+        {
+            get { return port; }
+            set { SetProperty(ref port, value); }
+        }
 
         /// <summary>The time interval, in milliseconds, after which a connection is retried</summary>
         public int ReconnectInterval
         {
             get { return recoveryTime.Milliseconds; }
-            set { recoveryTime = TimeSpan.FromMilliseconds(value); }
+            set { SetProperty(ref recoveryTime, TimeSpan.FromMilliseconds(value)); }
         }
 
         /// <summary>KeepAlive configuration</summary>
-        public KeepAliveConfig KeepAlive { get; set; }
+        public KeepAliveConfig KeepAlive
+        {
+            get { return keepAlive; }
+            set { SetProperty(ref keepAlive, value); }
+        }
 
         /// <summary>The time, in microseconds, to wait for a response when checking the connection status</summary>
-        public int ConnectionCheckTimeout { get; set; }
+        public int ConnectionCheckTimeout
+        {
+            get { return connectionCheckTimeout; }
+            set { SetProperty(ref connectionCheckTimeout, value); }
+        }
 
         /// <summary>Whether to use TLS or not (TLS 1.2 only)</summary>
-        public bool UseTls { get; set; }
+        public bool UseTls
+        {
+            get { return useTls; }
+            set { SetProperty(ref useTls, value); }
+        }
 
         /// <summary>Which framing method to use</summary>
         /// <remarks>If <see cref="UseTls">is true</see> get will always return OctetCounting (RFC 5425)</remarks>
         public FramingMethod Framing
         {
             get { return UseTls ? FramingMethod.OctetCounting : framing; }
-            set { framing = value; }
+            set { SetProperty(ref framing, value); }
         }
 
         /// <summary>The size of chunks in which data is split to be sent over the wire</summary>
-        public int DataChunkSize { get; set; }
+        public int DataChunkSize
+        {
+            get { return dataChunkSize; }
+            set { SetProperty(ref dataChunkSize, value); }
+        }
 
         /// <summary>Builds a new instance of the TcpProtocolConfig class</summary>
         public TcpConfig()
         {
-            Server = Localhost;
-            Port = DefaultPort;
-            ReconnectInterval = DefaultReconnectInterval;
-            KeepAlive = new KeepAliveConfig();
-            ConnectionCheckTimeout = DefaultConnectionCheckTimeout;
-            UseTls = true;
-            Framing = FramingMethod.OctetCounting;
-            DataChunkSize = DefaultBufferSize;
+            server = Localhost;
+            port = DefaultPort;
+            recoveryTime = TimeSpan.FromMilliseconds(DefaultReconnectInterval);
+            keepAlive = new KeepAliveConfig();
+            keepAlivePropsChanged = (sender, args) => OnPropertyChanged(nameof(KeepAlive));
+            keepAlive.PropertyChanged += keepAlivePropsChanged;
+            connectionCheckTimeout = DefaultConnectionCheckTimeout;
+            useTls = true;
+            framing = FramingMethod.OctetCounting;
+            dataChunkSize = DefaultBufferSize;
+        }
+
+        public void Dispose()
+        {
+            keepAlive.PropertyChanged -= keepAlivePropsChanged;
         }
     }
 }

--- a/src/NLog.Targets.Syslog/Settings/ThrottlingConfig.cs
+++ b/src/NLog.Targets.Syslog/Settings/ThrottlingConfig.cs
@@ -4,9 +4,10 @@
 namespace NLog.Targets.Syslog.Settings
 {
     /// <summary>Throttling configuration</summary>
-    public class ThrottlingConfig
+    public class ThrottlingConfig : NotifyPropertyChanged
     {
         private int limit;
+        private ThrottlingStrategy strategy;
         private decimal delay;
 
         /// <summary>The number of log entries, waiting to be processed, that triggers throttling</summary>
@@ -18,30 +19,37 @@ namespace NLog.Targets.Syslog.Settings
             }
             set
             {
-                limit = value;
+
                 if (value >= 1)
+                {
+                    SetProperty(ref limit, value);
                     return;
-                limit = 0;
+                }
+                SetProperty(ref limit, 0);
                 Strategy = ThrottlingStrategy.None;
             }
         }
 
         /// <summary>The throttling strategy to employ</summary>
-        public ThrottlingStrategy Strategy { get; set; }
+        public ThrottlingStrategy Strategy
+        {
+            get { return strategy; }
+            set { SetProperty(ref strategy, value); }
+        }
 
         /// <summary>The milliseconds/percentage delay for a DiscardOnFixedTimeout/DiscardOnPercentageTimeout/Defer throttling strategy</summary>
         public decimal Delay
         {
             get { return delay; }
-            set { delay = value < 0 ? 0 : value; }
+            set { SetProperty(ref delay, value < 0 ? 0 : value); }
         }
 
         /// <summary>Builds a new instance of the Throttling class</summary>
         public ThrottlingConfig()
         {
-            Limit = 0;
-            Strategy = ThrottlingStrategy.None;
-            Delay = 0;
+            limit = 0;
+            strategy = ThrottlingStrategy.None;
+            delay = 0;
         }
     }
 }

--- a/src/NLog.Targets.Syslog/Settings/UdpConfig.cs
+++ b/src/NLog.Targets.Syslog/Settings/UdpConfig.cs
@@ -4,22 +4,32 @@
 namespace NLog.Targets.Syslog.Settings
 {
     /// <summary>UDP configuration</summary>
-    public class UdpConfig
+    public class UdpConfig : NotifyPropertyChanged
     {
         private const string Localhost = "localhost";
         private const int DefaultPort = 514;
+        private string server;
+        private int port;
 
         /// <summary>The IP address or hostname of the Syslog server</summary>
-        public string Server { get; set; }
+        public string Server
+        {
+            get { return server; }
+            set { SetProperty(ref server, value); }
+        }
 
         /// <summary>The port number the Syslog server is listening on</summary>
-        public int Port { get; set; }
+        public int Port
+        {
+            get { return port; }
+            set { SetProperty(ref port, value); }
+        }
 
         /// <summary>Builds a new instance of the UdpProtocolConfig class</summary>
         public UdpConfig()
         {
-            Server = Localhost;
-            Port = DefaultPort;
+            server = Localhost;
+            port = DefaultPort;
         }
     }
 }

--- a/src/NLog.Targets.Syslog/SyslogTarget.cs
+++ b/src/NLog.Targets.Syslog/SyslogTarget.cs
@@ -14,7 +14,6 @@ namespace NLog.Targets.Syslog
     [Target("Syslog")]
     public class SyslogTarget : TargetWithLayout
     {
-        private volatile bool inited;
         private MessageBuilder messageBuilder;
         private AsyncLogger[] asyncLoggers;
 
@@ -40,12 +39,11 @@ namespace NLog.Targets.Syslog
         {
             base.InitializeTarget();
 
-            if (inited)
+            if (IsInitialized)
                 DisposeDependencies();
 
             messageBuilder = MessageBuilder.FromConfig(MessageCreation, Enforcement);
             asyncLoggers = Enforcement.MessageProcessors.Select(i => new AsyncLogger(Layout, Enforcement, messageBuilder, MessageSend)).ToArray();
-            inited = true;
         }
 
         /// <summary>Writes a single event</summary>

--- a/src/NLog.Targets.Syslog/SyslogTarget.cs
+++ b/src/NLog.Targets.Syslog/SyslogTarget.cs
@@ -1,12 +1,13 @@
 // Licensed under the BSD license
 // See the LICENSE file in the project root for more information
 
-using System;
-using System.Linq;
 using NLog.Common;
 using NLog.Targets.Syslog.Extensions;
 using NLog.Targets.Syslog.MessageCreation;
 using NLog.Targets.Syslog.Settings;
+using System;
+using System.ComponentModel;
+using System.Linq;
 
 namespace NLog.Targets.Syslog
 {
@@ -38,7 +39,14 @@ namespace NLog.Targets.Syslog
         protected override void InitializeTarget()
         {
             base.InitializeTarget();
+            Enforcement.PropertyChanged += Init;
+            MessageCreation.PropertyChanged += Init;
+            MessageSend.PropertyChanged += Init;
+            Init();
+        }
 
+        private void Init(object sender = null, PropertyChangedEventArgs eventArgs = null)
+        {
             if (IsInitialized)
                 DisposeDependencies();
 
@@ -61,7 +69,12 @@ namespace NLog.Targets.Syslog
         protected override void Dispose(bool disposing)
         {
             if (disposing)
+            {
+                Enforcement.PropertyChanged -= Init;
+                MessageCreation.PropertyChanged -= Init;
+                MessageSend.PropertyChanged -= Init;
                 DisposeDependencies();
+            }
             base.Dispose(disposing);
         }
 


### PR DESCRIPTION
On a target based on asynchrony it is quite tricky to perform fine grained actions on configuration changes.
Moreover changing IPs or ports is not such a frequent scenario: you usually have load balancers or plan configuration changes, applying them manually.

For the reasons described above and not to pollute and dirty the design, each configuration change re-inits the target.

IMHO it would be more appropriate for NLog to support a begin/end configuration change pattern to manage configuration changes on complex targets.